### PR TITLE
Return last -std argument from parseCppStd

### DIFF
--- a/src/ParserGcc.ts
+++ b/src/ParserGcc.ts
@@ -119,7 +119,6 @@ export class ParserGcc extends Parser {
             const std = lut.get(m[1]);
             if (std) {
                 result.cppStandard = std;
-                return;
             }
         }
     }

--- a/src/__tests__/ParserGcc.cpp-std.test.ts
+++ b/src/__tests__/ParserGcc.cpp-std.test.ts
@@ -63,6 +63,10 @@ const tests: {options: string[]; std: ResultCppStandard}[] = [
         options: [],
         std: ResultCppStandard.None,
     },
+    {
+        options: ["std=gnu++11", "-std=gnu++20"],
+        std: ResultCppStandard.Cpp20,
+    },
 ];
 
 for (const t of tests) {


### PR DESCRIPTION
gcc uses the last -std argument found on the command line:
```
$ g++ -std=gnu++11 -std=gnu++17 -dM -E -x c++ - < /dev/null | grep __cplusplus
#define __cplusplus 201703L
```

Modify parseCppStd to continue searching after finding the first -std argument.