### PR TITLE
Pass cppStandard when getting gcc builtins

### DIFF
--- a/src/BuiltInInfoParser.ts
+++ b/src/BuiltInInfoParser.ts
@@ -7,6 +7,8 @@
  *
  * All rights reserved.
  */
+import {ResultCppStandard} from "./Result";
+
 /**
  * Return value of any BuiltInInfoParser.
  * Contains the includes and other data which are intrinsically
@@ -32,5 +34,5 @@ export abstract class BuiltInInfoParser {
         return this._enabled;
     }
 
-    public abstract info(executable: string): IBuiltInInfo | undefined;
+    public abstract info(executable: string, cppStandard: ResultCppStandard): IBuiltInInfo | undefined;
 }

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -124,7 +124,7 @@ export abstract class Parser {
                 this._infoParser.enabled &&
                 res.compiler.length
             ) {
-                const nfo = this._infoParser.info(res.compiler);
+                const nfo = this._infoParser.info(res.compiler, res.cppStandard);
                 if (nfo) {
                     res.includes = [...res.includes, ...nfo.includes];
                     res.defines = [...res.defines, ...nfo.defines];

--- a/src/__tests__/ParserGcc.built-in.test.ts
+++ b/src/__tests__/ParserGcc.built-in.test.ts
@@ -9,6 +9,7 @@
  */
 import * as os from "os";
 import {ParserGcc} from "../ParserGcc";
+import {ResultCppStandard} from "../Result";
 import {makeExecSyncSpy} from "./mocks";
 import {gccGetBuiltInCmd, GccGetBuiltIn} from "../BuiltInInfoParserGcc";
 
@@ -26,11 +27,13 @@ for (const platform of ["win32", "darwin", "linux"]) {
         const execSyncSpy = makeExecSyncSpy([
             {
                 file: "gpp.amd64.builtin.includes.stimulus.txt",
-                pattern: gccGetBuiltInCmd(exe, GccGetBuiltIn.Includes),
+                pattern: gccGetBuiltInCmd(exe, ResultCppStandard.None,
+                                          GccGetBuiltIn.Includes),
             },
             {
                 file: "gpp.amd64.builtin.defines.stimulus.txt",
-                pattern: gccGetBuiltInCmd(exe, GccGetBuiltIn.Defines),
+                pattern: gccGetBuiltInCmd(exe, ResultCppStandard.None,
+                                          GccGetBuiltIn.Defines),
             },
         ]);
 


### PR DESCRIPTION
The -std= argument modifies important builtins such as __cplusplus, pass it to getGccBuiltInCmd to get accurate results based on the detected c++ standard.

Without this vscode-arduino shows squiggly errors when using features from a non-default c++ standard.